### PR TITLE
Clone System and Kill System

### DIFF
--- a/Engine/ECS/Components/Text.cs
+++ b/Engine/ECS/Components/Text.cs
@@ -3,7 +3,6 @@ using Engine.ECS;
 
 namespace BigBlue.ECS
 {
-    // TODO : Implement Clone method that returns a deep copy of this component. For use with undo mechanic.
     internal class Text
     {
         private TextType _type;

--- a/Engine/ECS/EntityCreator.cs
+++ b/Engine/ECS/EntityCreator.cs
@@ -194,24 +194,5 @@ namespace BigBlue.ECS
             killText.Attach(new Animation(spriteSheet, Color.White));
             killText.Attach(new Property(isPush: true));
         }
-
-        // TODO : Add to these two methods to suit what you need for the rules system. However you want to handle the Text component.
-        //public static void CreateNoun(World world, Vector2 position, Texture2D[] spriteSheet, Color color)
-        //{
-        //    var noun = world.CreateEntity();
-        //    noun.Attach(new Position(position));
-        //    noun.Attach(new Noun(NounType.Noun));
-        //    noun.Attach(new Animation(spriteSheet, color));
-        //    noun.Attach(new Property(isPush: true));
-        //}
-
-        //public static void CreateVerb(World world, Vector2 position, Texture2D[] spriteSheet, Color color)
-        //{
-        //    var verb = world.CreateEntity();
-        //    verb.Attach(new Position(position));
-        //    verb.Attach(new Noun(NounType.Verb));
-        //    verb.Attach(new Animation(spriteSheet, color));
-        //    verb.Attach(new Property(isPush: true));
-        //}
     }
 }

--- a/Engine/ECS/Systems/CloneSystem.cs
+++ b/Engine/ECS/Systems/CloneSystem.cs
@@ -1,0 +1,87 @@
+﻿using Microsoft.Xna.Framework;
+using Microsoft.Xna.Framework.Graphics;
+using MonoGame.Extended.Entities;
+using MonoGame.Extended.Entities.Systems;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace BigBlue.ECS
+{
+    internal class CloneSystem : EntityUpdateSystem
+    {
+        private ComponentMapper<Position> _positionMapper;
+
+        private int _gridWidth;
+        private int _gridHeight;
+        private int _renderStartX;
+        private SpriteBatch _spriteBatch;
+
+        public CloneSystem(int gridWidth, int gridHeight, int renderStartX, SpriteBatch spriteBatch)
+            : base(Aspect.All(typeof(Position)))
+        {
+            _gridWidth = gridWidth;
+            _gridHeight = gridHeight;
+            _renderStartX = renderStartX;
+            _spriteBatch = spriteBatch;
+        }
+
+        public override void Initialize(IComponentMapperService mapperService)
+        {
+            _positionMapper = mapperService.GetMapper<Position>();
+        }
+
+        public override void Update(GameTime gameTime)
+        {
+            if (GameStatus.playerMoved || WorldClone.undone)
+            {
+                var cloneWorld = new WorldBuilder()
+                    //.AddSystem(new MovementSystem())
+                    //.AddSystem(new RulesSystem())
+                    .AddSystem(new KillSystem(_gridWidth, _gridHeight, _renderStartX))
+                    .AddSystem(new WinSystem())
+                    .AddSystem(new AnimationSystem(_gridWidth, _gridHeight, _renderStartX, _spriteBatch))
+                    .AddSystem(new CloneSystem(_gridWidth, _gridHeight, _renderStartX, _spriteBatch))
+                    .Build();
+
+                foreach (var entityId in ActiveEntities)
+                {
+                    var cloneEntity = cloneWorld.CreateEntity();
+                    var originalEntity = GetEntity(entityId);
+
+                    Position positionClone = originalEntity.Get<Position>().Clone();
+                    cloneEntity.Attach(positionClone);
+
+                    if (GetEntity(entityId).Has<Animation>())
+                    {
+                        Animation animationClone = originalEntity.Get<Animation>().Clone();
+                        cloneEntity.Attach(animationClone);
+                    }
+
+                    if (GetEntity(entityId).Has<Object>())
+                    {
+                        Object objectClone = originalEntity.Get<Object>().Clone();
+                        cloneEntity.Attach(objectClone);
+                    }
+
+                    if (GetEntity(entityId).Has<Property>())
+                    {
+                        Property propertyClone = originalEntity.Get<Property>().Clone();
+                        cloneEntity.Attach(propertyClone);
+                    }
+
+                    if (GetEntity(entityId).Has<Text>())
+                    {
+                        Text textClone = originalEntity.Get<Text>().Clone();
+                        cloneEntity.Attach(textClone);
+                    }
+                }
+
+                WorldClone.cloneWorld = cloneWorld;
+
+            }
+        }
+    }
+}

--- a/Engine/ECS/Systems/KillSystem.cs
+++ b/Engine/ECS/Systems/KillSystem.cs
@@ -11,18 +11,69 @@ namespace BigBlue.ECS
 {
     internal class KillSystem : EntityUpdateSystem
     {
-        public KillSystem(AspectBuilder aspectBuilder) : base(aspectBuilder)
+        private ComponentMapper<Position> _positionMapper;
+        private ComponentMapper<Property> _propertyMapper;
+
+        private Rectangle _particleRectangle;
+        private int _gridWidth;
+        private int _gridHeight;
+        private int _renderStartX;
+
+        public KillSystem(int gridWidth, int gridHeight, int renderStartX) : base(Aspect.All(typeof(Position), typeof(Property)))
         {
+            _gridWidth = gridWidth;
+            _gridHeight = gridHeight;
+            _renderStartX = renderStartX;
+            _particleRectangle = new Rectangle(renderStartX, 0, gridWidth, gridHeight);
         }
 
         public override void Initialize(IComponentMapperService mapperService)
         {
-            throw new NotImplementedException();
+            _positionMapper = mapperService.GetMapper<Position>();
+            _propertyMapper = mapperService.GetMapper<Property>();
         }
 
         public override void Update(GameTime gameTime)
         {
-            throw new NotImplementedException();
+            // Entities will never need to be destroyed unless the player moved
+            if (GameStatus.playerMoved)
+            {
+                List<int> killEntities = new List<int>();
+
+                // Find positions of all isKill entities
+                foreach (var entityId in ActiveEntities)
+                {
+                    if (_propertyMapper.Get(entityId).isKill)
+                    {
+                        killEntities.Add(entityId);
+                    }
+                }
+
+                foreach (var killEntityId in killEntities)
+                {
+                    Position killPosition = _positionMapper.Get(killEntityId);
+                    foreach (var entityId in ActiveEntities)
+                    {
+                        if (entityId != killEntityId)
+                        {
+                            Position entityPosition = _positionMapper.Get(entityId);
+                            bool entityDestroyed = false;
+                            if (entityPosition.Coordinates == killPosition.Coordinates)
+                            {
+                                DestroyEntity(entityId);
+                                entityDestroyed = true;
+                            }
+                            if (entityDestroyed)
+                            {
+                                _particleRectangle.X = _renderStartX + ((int)entityPosition.Coordinates.X * _gridWidth);
+                                _particleRectangle.Y = (int)killPosition.Coordinates.Y * _gridHeight;
+                                ParticleSystem.OnDeath(_particleRectangle, 50, 2f, new TimeSpan(0, 0, 0, 0, 1500), Color.Yellow);
+                                DestroyEntity(killEntityId);
+                            }
+                        }
+                    }
+                }
+            }
         }
     }
 }

--- a/Engine/ECS/Systems/WinSystem.cs
+++ b/Engine/ECS/Systems/WinSystem.cs
@@ -30,46 +30,50 @@ namespace BigBlue.ECS
 
         public override void Update(GameTime gameTime)
         {
-            // Lists for the position components of all entities with "isYou" property
-            // and "isWin" property.
-            List<Position> isYouEntities = new List<Position>();
-            List<Position> isWinEntities = new List<Position>();
-
-            // Loop through all entities tracked by the WinSystem
-            foreach (int entityId in ActiveEntities)
+            // Win condition will never be met unless the player moved
+            if (GameStatus.playerMoved)
             {
-                // Get the property component of the entity
-                Property property = _propertyMapper.Get(entityId);
+                // Lists for the position components of all entities with "isYou" property
+                // and "isWin" property.
+                List<Position> isYouEntities = new List<Position>();
+                List<Position> isWinEntities = new List<Position>();
 
-                // If an object is both you and win, the win condition is met
-                if (property.isYou && property.isWin)
+                // Loop through all entities tracked by the WinSystem
+                foreach (int entityId in ActiveEntities)
                 {
-                    GameStatus.playerWon = true;
-                    return;
-                }
+                    // Get the property component of the entity
+                    Property property = _propertyMapper.Get(entityId);
 
-                //Otherwise, add their positions to the lists if they are "isYou" or "isWin"
-                if (property.isYou)
-                {
-                    isYouEntities.Add(_positionMapper.Get(entityId));
-                }
-                if (property.isWin)
-                {
-                    isWinEntities.Add(_positionMapper.Get(entityId));
-                }
-            }
-
-            // Loop through the "isYou" and "isWin" lists
-            foreach (var youPosition in isYouEntities)
-            {
-                Vector2 youCoordinates = youPosition.Coordinates;
-                foreach (var winPosition in isWinEntities)
-                {
-                    // If an "isYou" entity matches position with an "isWin" entity, the win condition is met
-                    if (youCoordinates == winPosition.Coordinates)
+                    // If an object is both you and win, the win condition is met
+                    if (property.isYou && property.isWin)
                     {
                         GameStatus.playerWon = true;
                         return;
+                    }
+
+                    //Otherwise, add their positions to the lists if they are "isYou" or "isWin"
+                    if (property.isYou)
+                    {
+                        isYouEntities.Add(_positionMapper.Get(entityId));
+                    }
+                    if (property.isWin)
+                    {
+                        isWinEntities.Add(_positionMapper.Get(entityId));
+                    }
+                }
+
+                // Loop through the "isYou" and "isWin" lists
+                foreach (var youPosition in isYouEntities)
+                {
+                    Vector2 youCoordinates = youPosition.Coordinates;
+                    foreach (var winPosition in isWinEntities)
+                    {
+                        // If an "isYou" entity matches position with an "isWin" entity, the win condition is met
+                        if (youCoordinates == winPosition.Coordinates)
+                        {
+                            GameStatus.playerWon = true;
+                            return;
+                        }
                     }
                 }
             }

--- a/Engine/ECS/WorldClone.cs
+++ b/Engine/ECS/WorldClone.cs
@@ -1,0 +1,10 @@
+﻿using MonoGame.Extended.Entities;
+
+namespace BigBlue
+{
+    public static class WorldClone
+    {
+        public static bool undone;
+        public static World cloneWorld;
+    }
+}

--- a/Engine/ECS/WorldCreator.cs
+++ b/Engine/ECS/WorldCreator.cs
@@ -29,9 +29,10 @@ namespace BigBlue
             var world = new WorldBuilder()
                 //.AddSystem(new MovementSystem())
                 //.AddSystem(new RulesSystem())
-                .AddSystem(new AnimationSystem(gridWidth, gridHeight, renderStartX, spriteBatch))
-                //.AddSystem(new KillSystem())
+                .AddSystem(new KillSystem(gridWidth, gridHeight, renderStartX))
                 .AddSystem(new WinSystem())
+                .AddSystem(new AnimationSystem(gridWidth, gridHeight, renderStartX, spriteBatch))
+                .AddSystem(new CloneSystem(gridWidth, gridHeight, renderStartX, spriteBatch))
                 .Build();
 
             // TODO: Create Entities based on the Level's Object Layout

--- a/Engine/GameState/LevelSelectView.cs
+++ b/Engine/GameState/LevelSelectView.cs
@@ -43,6 +43,7 @@ namespace BigBlue
                 if (Keyboard.GetState().IsKeyDown(Keys.Escape))
                 {
                     waitForKeyRelease = true;
+                    LevelManager.Instance.ResetCurrentLevelIndex();
                     return GameStateEnum.MainMenu;
                 }
             }

--- a/Engine/Levels/LevelManager.cs
+++ b/Engine/Levels/LevelManager.cs
@@ -31,6 +31,11 @@ namespace BigBlue
             return _levels[_currentLevelIndex];
         }
 
+        public void ResetCurrentLevelIndex()
+        {
+            _currentLevelIndex = 0;
+        }
+
         #region Level Adding
         public void CreateAllLevels(string allLevelsFile = "../../../Content/Levels/levels-all.bbiy")
         {


### PR DESCRIPTION
Clone System clones a world when the player moves or undoes a move
Kill system destroys entities that share a space with an "isKill" entity. Currently, the implementation also destroys the "isKill" entity, but this can be easily modified. Not sure if the proper behavior mandates one way or the other.
Minor code cleanup
Level Select menu now resets to the top level when navigating between Main Menu, Level Select, and Gameplay states.